### PR TITLE
add missing dependency when running npm run watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
+    "babel-core": "^6.17.0",
     "chart.js": "^2.2.2",
     "es6-promise": "^3.3.1",
     "object-path": "^0.11.2",


### PR DESCRIPTION
Fix error message when running `npm run watch`.
`babel-core` was missing in `package.json`
