### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package.json,.travis.yml}]
+; The indent size used in the `package.json` file cannot be changed
+; https://github.com/npm/npm/pull/3180#issuecomment-16336516
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
I think adding a .editorconfig can help reduce whitespace diffs and normalise the size of the tabs across the project. Particularly useful when multiple people contribute to the same project.

PS: It might also be worth adding es-lint (combined with Travis ideally).
