### PR TITLE
Added link to webpagetest-api npmjs.com page in _profiles/default.html

### DIFF
--- a/_profiles/default.html
+++ b/_profiles/default.html
@@ -19,7 +19,10 @@ default: true
 interval: 12
 
 #
-# WebPageTest test parameters
+# WebPageTest test parameters.
+# For a list of supported params, check:
+#
+# https://www.npmjs.com/package/webpagetest
 #
 parameters:
   connectivity: "Cable"


### PR DESCRIPTION
This is something super simple to document the usage of  [**marcelduran/webpagetest-api**](https://github.com/marcelduran/webpagetest-api/tree/master) since the params for this lib do not match the params of the [webpagetest.org api](https://sites.google.com/a/webpagetest.org/docs/advanced-features/webpagetest-restful-apis).

I'm not really sure this is sufficient to prevent all confusion though since [webpagetest-api](https://www.npmjs.com/package/webpagetest) refers to params as options and displays them with leading `--` for CLI usage. I would be open to any ideas for improvements or additional wording that might prevent possible confusion.